### PR TITLE
Fix puppet manifest for ansible folder

### DIFF
--- a/config_management_tools/ansible/Vagrantfile
+++ b/config_management_tools/ansible/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
   config.hostmanager.ignore_private_ip = false
   #update the /etc/hosts of the host OS
   config.hostmanager.manage_host = true
-  
+
   #Puppet and Ansible master
   config.vm.define "ansiblemaster".to_sym do |ansiblemaster_config|
     ansiblemaster_config.vm.box = "ubuntu-14.04-server-amd64"
@@ -18,9 +18,9 @@ Vagrant.configure("2") do |config|
     ansiblemaster_config.hostmanager.aliases = %w(puppetboard.ansiblemaster.local ansiblemaster puppet master ansible.ansiblemaster.local)
     ansiblemaster_config.hostmanager.enabled = true
     ansiblemaster_config.vm.network :private_network, ip: "10.0.1.80"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansiblemaster_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "2048"]
     end
     #Set up synced folders for Puppet code:
@@ -36,12 +36,12 @@ Vagrant.configure("2") do |config|
     ansible1_config.vm.hostname = "ansible1.local"
     ansible1_config.hostmanager.enabled = true
     ansible1_config.vm.network :private_network, ip: "10.0.1.81"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansible1_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "512"]
     end
-    ansible1_config.vm.provision :shell, :path => "../provisioning_scripts/ubuntu_puppet_agent.sh" 
+    ansible1_config.vm.provision :shell, :path => "../provisioning_scripts/ubuntu_puppet_agent.sh"
   end
 
   #Another Ansible node
@@ -50,12 +50,12 @@ Vagrant.configure("2") do |config|
     ansible2_config.vm.hostname = "ansible2.local"
     ansible2_config.hostmanager.enabled = true
     ansible2_config.vm.network :private_network, ip: "10.0.1.82"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansible2_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "512"]
     end
-    ansible2_config.vm.provision :shell, :path => "../provisioning_scripts/ubuntu_puppet_agent.sh" 
+    ansible2_config.vm.provision :shell, :path => "../provisioning_scripts/ubuntu_puppet_agent.sh"
   end
 
   #Another Ansible node
@@ -64,23 +64,23 @@ Vagrant.configure("2") do |config|
     ansible3_config.vm.hostname = "ansible3.local"
     ansible3_config.hostmanager.enabled = true
     ansible3_config.vm.network :private_network, ip: "10.0.1.83"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansible3_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "512"]
     end
     ansible3_config.vm.provision :shell, :path => "../provisioning_scripts/el6_puppet_agent.sh"
   end
-  
+
   #Another Ansible node
   config.vm.define "ansible4".to_sym do |ansible4_config|
     ansible4_config.vm.box = "centos-6.6-amd64"
     ansible4_config.vm.hostname = "ansible4.local"
     ansible4_config.hostmanager.enabled = true
     ansible4_config.vm.network :private_network, ip: "10.0.1.84"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansible4_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "512"]
     end
     ansible4_config.vm.provision :shell, :path => "../provisioning_scripts/el6_puppet_agent.sh"
@@ -92,12 +92,12 @@ Vagrant.configure("2") do |config|
     ansible5_config.vm.hostname = "ansible5.local"
     ansible5_config.hostmanager.enabled = true
     ansible5_config.vm.network :private_network, ip: "10.0.1.85"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansible5_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "512"]
     end
-    ansible5_config.vm.provision :shell, :path => "../provisioning_scripts/ubuntu_puppet_agent.sh" 
+    ansible5_config.vm.provision :shell, :path => "../provisioning_scripts/ubuntu_puppet_agent.sh"
   end
 
   #another ansible server
@@ -106,9 +106,9 @@ Vagrant.configure("2") do |config|
     ansible6_config.vm.hostname = "ansible6.local"
     ansible6_config.hostmanager.enabled = true
     ansible6_config.vm.network :private_network, ip: "10.0.1.86"
-    #set some machine-specific options	
+    #set some machine-specific options
     ansible6_config.vm.provider "virtualbox" do |v|
-      #change the amount of RAM 
+      #change the amount of RAM
       v.customize ["modifyvm", :id, "--memory", "512"]
     end
     ansible6_config.vm.provision :shell, :path => "../provisioning_scripts/el6_puppet_agent.sh"

--- a/config_management_tools/ansible/manifests/site.pp
+++ b/config_management_tools/ansible/manifests/site.pp
@@ -10,7 +10,7 @@ node default {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -31,9 +31,9 @@ node 'ansiblemaster.local' {
   class { 'puppetdb':
     listen_address => '0.0.0.0'
   }
-  
+
   include puppetdb::master::config
-  
+
   #Apache modules for PuppetBoard:
   class { 'apache': }
   class { 'apache::mod::wsgi': }
@@ -48,7 +48,7 @@ node 'ansiblemaster.local' {
     vhost_name => "puppetboard.${fqdn}",
     port => 80,
   }
- 
+
   #This module is from: https://github.com/saz/puppet-rsyslog
   class { 'rsyslog::server':
     enable_tcp => true,
@@ -78,7 +78,7 @@ node 'ansible1.local' {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -97,7 +97,7 @@ node 'ansible1.local' {
     log_local      => true,
     log_auth_local => true,
     custom_config  => undef,
-    server         => 'saltmaster.local',
+    server         => 'ansiblemaster.local',
     port           => '514',
   }
 
@@ -122,7 +122,7 @@ node 'ansible2.local' {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -141,7 +141,7 @@ node 'ansible2.local' {
     log_local      => true,
     log_auth_local => true,
     custom_config  => undef,
-    server         => 'saltmaster.local',
+    server         => 'ansiblemaster.local',
     port           => '514',
   }
 
@@ -166,7 +166,7 @@ node 'ansible3.local' {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -185,7 +185,7 @@ node 'ansible3.local' {
     log_local      => true,
     log_auth_local => true,
     custom_config  => undef,
-    server         => 'saltmaster.local',
+    server         => 'ansiblemaster.local',
     port           => '514',
   }
 
@@ -210,7 +210,7 @@ node 'ansible4.local' {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -229,10 +229,10 @@ node 'ansible4.local' {
     log_local      => true,
     log_auth_local => true,
     custom_config  => undef,
-    server         => 'saltmaster.local',
+    server         => 'ansiblemaster.local',
     port           => '514',
   }
-  
+
   #This module is: https://github.com/puppetlabs/puppetlabs-ntp
   class { '::ntp':
     servers  => [ '0.centos.pool.node.org', '1.centos.pool.node.org', '2.centos.pool.node.org', '3.centos.pool.node.org' ],
@@ -253,7 +253,7 @@ node 'ansible5.local' {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -272,10 +272,10 @@ node 'ansible5.local' {
     log_local      => true,
     log_auth_local => true,
     custom_config  => undef,
-    server         => 'saltmaster.local',
+    server         => 'ansiblemaster.local',
     port           => '514',
   }
-  
+
   #This module is: https://github.com/puppetlabs/puppetlabs-ntp
   class { '::ntp':
     servers  => [ '0.ubuntu.pool.ntp.org', '1.ubuntu.pool.ntp.org', '2.ubuntu.pool.ntp.org', '3.ubuntu.pool.ntp.org' ],
@@ -297,7 +297,7 @@ node 'ansible6.local' {
       #'PasswordAuthentication' => 'no',
       #How many authentication attempts to allow before disconnecting:
       'MaxAuthTries'         => '10',
-      'PermitEmptyPasswords' => 'no', 
+      'PermitEmptyPasswords' => 'no',
       'PermitRootLogin'      => 'no',
       'Port'                 => [22],
       'PubkeyAuthentication' => 'yes',
@@ -316,10 +316,10 @@ node 'ansible6.local' {
     log_local      => true,
     log_auth_local => true,
     custom_config  => undef,
-    server         => 'saltmaster.local',
+    server         => 'ansiblemaster.local',
     port           => '514',
   }
-  
+
   #This module is: https://github.com/puppetlabs/puppetlabs-ntp
   class { '::ntp':
     servers  => [ '0.centos.pool.node.org', '1.centos.pool.node.org', '2.centos.pool.node.org', '3.centos.pool.node.org' ],


### PR DESCRIPTION
The site.pp for the config_management_tools/ansible/ folder had parts
claiming the syslog, etc server was 'saltmaster.local', these have been
replaced with ansiblemaster.local, the correct server name.
Also cleaned up trailing whitespace in those two files since I was
there.

How would you like to get ansible installed on the ansible master? If you want
 to make that manual that is fine.